### PR TITLE
Add error message when button number can't be parsed

### DIFF
--- a/src/naga.cpp
+++ b/src/naga.cpp
@@ -133,6 +133,13 @@ void loadConf(string configName) {
 				}
 
 				if(configKeysMap.contains(commandType)) { //filter out bad types
+					int buttonNumberI;
+					try {
+						buttonNumberI = stoi(buttonNumber);
+					} catch (...) {
+						clog << "At config line " << readingLine << ": expected a number" << endl;
+						exit(1);
+					}
 					if(commandType=="key") {
 						if(commandContent.size()==1) {
 							commandContent = hexChar(commandContent[0]);

--- a/src/naga.cpp
+++ b/src/naga.cpp
@@ -144,16 +144,16 @@ void loadConf(string configName) {
 						if(commandContent.size()==1) {
 							commandContent = hexChar(commandContent[0]);
 						}
-						macroEventsKeyMap[configName][stoi(buttonNumber)].emplace_back(new MacroEvent(configKeysMap["keypressonpress"], &commandType, &commandContent));
-						macroEventsKeyMap[configName][stoi(buttonNumber)].emplace_back(new MacroEvent(configKeysMap["keyreleaseonrelease"], &commandType, &commandContent));
+						macroEventsKeyMap[configName][buttonNumberI].emplace_back(new MacroEvent(configKeysMap["keypressonpress"], &commandType, &commandContent));
+						macroEventsKeyMap[configName][buttonNumberI].emplace_back(new MacroEvent(configKeysMap["keyreleaseonrelease"], &commandType, &commandContent));
 					}else if(commandType=="string" || commandType=="stringrelease") {
 						string commandContent2="";
 						for(long unsigned jj=0; jj<commandContent.size(); jj++) {
 							commandContent2 += " "+hexChar(commandContent[jj]);
 						}
-						macroEventsKeyMap[configName][stoi(buttonNumber)].emplace_back(new MacroEvent(configKeysMap[commandType], &commandType, &commandContent2));
+						macroEventsKeyMap[configName][buttonNumberI].emplace_back(new MacroEvent(configKeysMap[commandType], &commandType, &commandContent2));
 					}else{
-						macroEventsKeyMap[configName][stoi(buttonNumber)].emplace_back(new MacroEvent(configKeysMap[commandType], &commandType, &commandContent));
+						macroEventsKeyMap[configName][buttonNumberI].emplace_back(new MacroEvent(configKeysMap[commandType], &commandType, &commandContent));
 					}//Encode and store mapping v3
 				}
 			}


### PR DESCRIPTION
When the number at the start of the line is missing or malformed (typo, forgetfulness, etc), this adds a clean error message.

## Example

```
config=defaultConfig
3 - key = 4
key = 6
configEnd
```

## Previous behaviour

```
score@kirisame ~/src/Razer_Mouse_Linux (git)-[master] % ./naga -debug
Stopping possible naga daemon
sh: 1: /usr/local/bin/killroot.sh: not found
Starting naga daemon in debug mode...
sh: 1: /usr/local/bin/nagaXinputStart.sh: not found
Reading from: /dev/input/by-id/usb-Razer_Razer_Naga_Chroma-if02-event-kbd and /dev/input/by-id/usb-Razer_Razer_Naga_Chroma-event-mouse
terminate called after throwing an instance of 'std::invalid_argument'
  what():  stoi
[1]    2203779 abort (core dumped)  ./naga -debug
```
IMO, this looks like a program bug and will make the user suspect that the program is broken rather than that their config is wrong.

Please ignore the `not found`s :wink: 

## New behaviour

```
score@kirisame ~/src/Razer_Mouse_Linux (git)-[patch-1] % ./naga -debug
Stopping possible naga daemon
sh: 1: /usr/local/bin/killroot.sh: not found
Starting naga daemon in debug mode...
sh: 1: /usr/local/bin/nagaXinputStart.sh: not found
Reading from: /dev/input/by-id/usb-Razer_Razer_Naga_Chroma-if02-event-kbd and /dev/input/by-id/usb-Razer_Razer_Naga_Chroma-event-mouse
At config line 3: expected a number
```