### PR TITLE
Fix bugs in src/nagaUninstall.sh

### DIFF
--- a/src/nagaUninstall.sh
+++ b/src/nagaUninstall.sh
@@ -1,28 +1,38 @@
 #!/bin/sh
-sh /usr/local/bin/Naga_Linux/nagaKillroot.sh
+[ -f /usr/local/bin/Naga_Linux/nagaKillroot.sh ] && sh /usr/local/bin/Naga_Linux/nagaKillroot.sh
 sleep 0.3
 printf '%s\n' "Deleting app"
+
+sudo systemctl stop naga >/dev/null 2>&1
+sudo systemctl disable naga >/dev/null 2>&1
+
 #Deleting nagaDotool wrappers
 sudo rm -vf /usr/local/bin/nagaDotool /usr/local/bin/nagaDotoolc /usr/local/bin/nagaDotoold
-sudo rm -rvf /run/.nagaProtected
+# Note: _installWayland.sh's tmpfiles.d rule creates /run/nagaProtected (no leading dot)
+sudo rm -rvf /run/nagaProtected
 sudo rm -vf /etc/tmpfiles.d/nagaProtected.conf
 
-sudo gnome-extensions disable window-calls-extended@hseliger.eu
-sudo gnome-extensions uninstall -q window-calls-extended@hseliger.eu
-sudo groupdel razerInputGroup
+# gnome-extensions is per-user session state; running it under sudo would act
+# on root's own (nonexistent) session instead of the real user's.
+gnome-extensions disable window-calls-extended@hseliger.eu >/dev/null 2>&1
+gnome-extensions uninstall -q window-calls-extended@hseliger.eu >/dev/null 2>&1
+sudo groupdel razerInputGroup 2>/dev/null || true
 
 sudo rm -vf /usr/local/bin/nagaX11
 sudo rm -vf /usr/local/bin/nagaWayland
 sudo rm -vf /etc/udev/rules.d/80-naga.rules
 sudo rm -vf /etc/udev/rules.d/80-nagaWayland.rules
 sudo rm -vf /etc/systemd/system/naga.service
+sudo systemctl daemon-reload
+sudo udevadm control --reload-rules
+sudo udevadm trigger
 sudo setsid rm -rvf /usr/local/bin/Naga_Linux/
 
-# Attempt to remove Naga sudoers includes
-if [ -f /etc/sudoers.d/naga ]; then
-	printf '%s\n' "Removing Naga sudoers.d entries..."
-	sudo rm -vf /etc/sudoers.d/naga
-fi
+# Remove Naga sudoers includes.
+# /etc/sudoers.d isn't readable without root (mode 0750), so a `[ -f ... ]`
+# check here as the regular user would silently always be false - just rm -f.
+printf '%s\n' "Removing Naga sudoers.d entries..."
+sudo rm -vf /etc/sudoers.d/naga
 
 sudo visudo -c
 


### PR DESCRIPTION
## What

Fixes real bugs in `src/nagaUninstall.sh` (the script `naga uninstall` runs) found while testing an uninstall against a real install:

- It removed `/run/.nagaProtected`, but `_installWayland.sh`'s tmpfiles.d rule actually creates `/run/nagaProtected` (no leading dot) — so the runtime dir was never actually being cleaned up.
- Its `[ -f /etc/sudoers.d/naga ]` guard runs as the regular user, but `/etc/sudoers.d` isn't readable without root (mode 0750), so the check silently always evaluated false and the sudoers drop-in was left behind regardless of whether it existed. Now just `sudo rm -f` directly instead of gating on an unprivileged existence check.
- `sudo gnome-extensions ...` acts on root's own (nonexistent) GNOME session instead of the real user's, so the extension disable/uninstall calls were silently no-ops. Dropped the `sudo`, matching how `nagaServerCatcher.sh` already calls `gnome-extensions`.

Also fills in steps the script was missing entirely: it deleted `naga.service` without ever stopping/disabling it or running `systemctl daemon-reload`, and removed the udev rule files without `udevadm control --reload-rules` / `udevadm trigger` — leaving stale state in both systemd and udev after "uninstall".

Guarded the initial `nagaKillroot.sh` call with an existence check so this doesn't fail outright if it's ever run against a partial/already-broken install.

## Testing

These exact commands (stop/disable `naga.service`, `rm -rf /run/nagaProtected`, `rm /etc/sudoers.d/naga`, `daemon-reload`, udev reload/trigger, un-sudo'd `gnome-extensions` calls) were run and verified live on a real install (Fedora, Wayland) via a since-dropped standalone script with identical logic — `naga.service` gone from systemd, no leftover processes, `/run/nagaProtected` actually removed, `/etc/sudoers.d/naga` actually removed (`visudo -c` clean), `razerInputGroup` gone, no naga binaries left under `/usr/local/bin`. This exact file (as invoked by `naga uninstall`) hasn't been re-run end-to-end since, since the machine now has nothing left installed to uninstall. `shellcheck` is clean on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
